### PR TITLE
Support multi-auth in generated CLIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## 2020-01-17
+- Add support for multi-auth, where two different auth schemes can be used. This
+  adds a new `cli.UseAuth(typeName, AuthHandler)` method that can be used to
+  register new auth types by name. This is *backward compatible* and the
+  existing (but now deprecated) credentials calls continue to work, but cannot
+  be used in conjuction with the new auth system.
+
 ## 2020-01-10
 - Add support for OAuth2 Authorization Code with PKCE https://oauth.net/2/pkce/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   adds a new `cli.UseAuth(typeName, AuthHandler)` method that can be used to
   register new auth types by name. This is *backward compatible* and the
   existing (but now deprecated) credentials calls continue to work, but cannot
-  be used in conjuction with the new auth system.
+  be used in conjuction with the new multi-auth system.
 
 ## 2020-01-10
 - Add support for OAuth2 Authorization Code with PKCE https://oauth.net/2/pkce/

--- a/README.md
+++ b/README.md
@@ -324,14 +324,14 @@ func main() {
   clientID := "abc123"
   issuer := "https://mycompany.auth0.com/"
 
-  oauth.InitAuthCode(clientID, issuer+"authorize", issuer+"oauth/token",
-    oauth.Scopes("offline_access"),
-		oauth.Extra("audience"),
-		oauth.GetParams(func(profile map[string]string) url.Values {
-			return url.Values{
-				"audience": {profile["audience"]},
-			}
-		}))
+  cli.UseAuth("user", &oauth.AuthCodeHandler{
+    ClientID: "clientID",
+    AuthorizeURL: issuer+"authorize",
+    TokenURL: issuer+"oauth/token",
+    Keys: []string{"audience"},
+    Params: []string{"audience"},
+    Scopes: []string{"offline_access"},
+  })
 
   // TODO: Register API commands here
   // ...
@@ -343,7 +343,7 @@ func main() {
 Note that there is a convenience module when using Auth0 specifically, allowing you to do this:
 
 ```go
-auth0.InitAuthCode(clientID, issuer)
+auth0.InitAuthCode(clientID, issuer, auth0.Scopes("offline_access"))
 ```
 
 The expanded example above is more useful when integrating with other services since it uses basic OAuth 2 primitives.

--- a/README.md
+++ b/README.md
@@ -343,7 +343,9 @@ func main() {
 Note that there is a convenience module when using Auth0 specifically, allowing you to do this:
 
 ```go
-auth0.InitAuthCode(clientID, issuer, auth0.Scopes("offline_access"))
+auth0.InitAuthCode(clientID, issuer,
+  auth0.Type("user"),
+  auth0.Scopes("offline_access"))
 ```
 
 The expanded example above is more useful when integrating with other services since it uses basic OAuth 2 primitives.

--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ $ my-cli --help
 
 Several extensions properties may be used to change the behavior of the CLI.
 
-Name | Description
----- | -----------
-`x-cli-aliases` | Sets up command aliases for operations.
-`x-cli-description` | Provide an alternate description for the CLI.
-`x-cli-ignore` | Ignore this path, operation, or parameter.
-`x-cli-hidden` | Hide this path, or operation.
-`x-cli-name` | Provide an alternate name for the CLI.
-`x-cli-waiters` | Generate commands/params to wait until a certain state is reached.
+| Name                | Description                                                        |
+| ------------------- | ------------------------------------------------------------------ |
+| `x-cli-aliases`     | Sets up command aliases for operations.                            |
+| `x-cli-description` | Provide an alternate description for the CLI.                      |
+| `x-cli-ignore`      | Ignore this path, operation, or parameter.                         |
+| `x-cli-hidden`      | Hide this path, or operation.                                      |
+| `x-cli-name`        | Provide an alternate name for the CLI.                             |
+| `x-cli-waiters`     | Generate commands/params to wait until a certain state is reached. |
 
 ### Aliases
 
@@ -83,7 +83,7 @@ paths:
     get:
       operationId: ListItems
       x-cli-aliases:
-      - ls
+        - ls
 ```
 
 ### Description
@@ -130,9 +130,9 @@ paths:
     operationId: myOperation
     x-cli-name: my-op
     parameters:
-    - name: id
-      x-cli-name: item-id
-      in: query
+      - name: id
+        x-cli-name: item-id
+        in: query
 ```
 
 With the above, you would be able to call `my-cli my-op --item-id=12`.
@@ -152,8 +152,8 @@ paths:
       operationId: GetOrder
       description: Get an order's details.
       parameters:
-      - name: id
-        in: path
+        - name: id
+          in: path
       responses:
         200:
           content:
@@ -170,8 +170,8 @@ x-cli-waiters:
     attempts: 10
     operationId: GetOrder
     matchers:
-    - select: response.body#status
-      expected: charged
+      - select: response.body#status
+        expected: charged
 ```
 
 The generated CLI will work like this: `my-cli wait order-charged $ID` where `$ID` corresponds to the `GetOrder` operation's `id` parameter. It will try to get and match the status 10 times, with a pause of 30 seconds between tries. If it matches, it will exit with a zero status code. If it fails, it will exit with a non-zero exit code and log a message.
@@ -187,11 +187,11 @@ x-cli-waiters:
     attempts: 10
     operationId: GetOrder
     matchers:
-    - select: response.body#status
-      expected: charged
-    - select: response.status
-      expected: 404
-      state: failure
+      - select: response.body#status
+        expected: charged
+      - select: response.status
+        expected: 404
+        state: failure
     after:
       CreateOrder:
         id: response.body#order_id
@@ -201,7 +201,7 @@ Here we added two new features:
 
 1. A short-circuit to fail fast. If we type an invalid order ID then we want the command to exit immediately with a non-zero exit code.
 
-2. The `after` block allows us to add a parameter to an *existing* operation to invoke the waiter. This block says that after a call to `CreateOrder` with a `--wait-order-charged` param, it should call the waiter's `GetOrder` operation with the `id` param set to the result of the `response.body#order_id` selector.
+2. The `after` block allows us to add a parameter to an _existing_ operation to invoke the waiter. This block says that after a call to `CreateOrder` with a `--wait-order-charged` param, it should call the waiter's `GetOrder` operation with the `id` param set to the result of the `response.body#order_id` selector.
 
 You can now create and wait on an order via `my-cli create-order <order.json --wait-order-charged`.
 
@@ -209,22 +209,22 @@ You can now create and wait on an order via `my-cli create-order <order.json --w
 
 The following matcher fields are available:
 
-Field | Description | Example
------ | ----------- | -------
-`select` | The value selection criteria. See the selector table below. | `response.status`
-`test` | The test to perform. Defaults to `equal` but can be set to `any` and `all` to match list items. | `equal`
-`expected` | The expected value | `charged`
-`state` | The state to set. Defaults to `success` but can be set to `failure`. | `success`
+| Field      | Description                                                                                     | Example           |
+| ---------- | ----------------------------------------------------------------------------------------------- | ----------------- |
+| `select`   | The value selection criteria. See the selector table below.                                     | `response.status` |
+| `test`     | The test to perform. Defaults to `equal` but can be set to `any` and `all` to match list items. | `equal`           |
+| `expected` | The expected value                                                                              | `charged`         |
+| `state`    | The state to set. Defaults to `success` but can be set to `failure`.                            | `success`         |
 
 The following selectors are available:
 
-Selector | Description | Argument | Example
--------- | ----------- | -------- | -------
-`request.param` | Request parameter | Parameter name | `request.param#id`
-`request.body` | Request body query | JMESPath query | `request.body#order.id`
-`response.status` | Response HTTP status code | - | `response.status`
-`response.header` | Response HTTP header | Header name | `response.header#content-type`
-`response.body` | Response body query | JMESPath query | `response.body#orders[].status`
+| Selector          | Description               | Argument       | Example                         |
+| ----------------- | ------------------------- | -------------- | ------------------------------- |
+| `request.param`   | Request parameter         | Parameter name | `request.param#id`              |
+| `request.body`    | Request body query        | JMESPath query | `request.body#order.id`         |
+| `response.status` | Response HTTP status code | -              | `response.status`               |
+| `response.header` | Response HTTP header      | Header name    | `response.header#content-type`  |
+| `response.body`   | Response body query       | JMESPath query | `response.body#orders[].status` |
 
 ## Customization
 
@@ -304,9 +304,49 @@ If the `foo` command would normally return a JSON object like `{"hello": "world"
 }
 ```
 
-### Authentication
+### Authentication & Authorization
 
-See the `apikey` module for an example. More docs coming soon.
+See the `apikey` module for a simple example of a pre-shared key.
+
+If instead you use a third party auth system that vends tokens and want your users to be able to log in and use the API, here's an example using Auth0:
+
+```go
+func main() {
+	cli.Init(&cli.Config{
+		AppName:   "example",
+		EnvPrefix: "EXAMPLE",
+		Version:   "1.0.0",
+	})
+
+  // Auth0 requires a client ID, issuer base URL, and audience fields when
+  // requesting a token. We set these up here and use the Authorization Code
+  // with PKCE flow to log in, which opens a browser for the user to log into.
+  clientID := "abc123"
+  issuer := "https://mycompany.auth0.com/"
+
+  oauth.InitAuthCode(clientID, issuer+"authorize", issuer+"oauth/token",
+    oauth.Scopes("offline_access"),
+		oauth.Extra("audience"),
+		oauth.GetParams(func(profile map[string]string) url.Values {
+			return url.Values{
+				"audience": {profile["audience"]},
+			}
+		}))
+
+  // TODO: Register API commands here
+  // ...
+
+	cli.Root.Execute()
+}
+```
+
+Note that there is a convenience module when using Auth0 specifically, allowing you to do this:
+
+```go
+auth0.InitAuthCode(clientID, issuer)
+```
+
+The expanded example above is more useful when integrating with other services since it uses basic OAuth 2 primitives.
 
 ## Development
 

--- a/auth0/auth0.go
+++ b/auth0/auth0.go
@@ -7,7 +7,8 @@ import (
 )
 
 type config struct {
-	extra []string
+	extra  []string
+	scopes []string
 }
 
 // Extra provides the names of additional parameters to use to store information
@@ -15,6 +16,15 @@ type config struct {
 func Extra(names ...string) func(*config) error {
 	return func(c *config) error {
 		c.extra = names
+		return nil
+	}
+}
+
+// Scopes are used to request additional information or features for the
+// returned token.
+func Scopes(scopes ...string) func(*config) error {
+	return func(c *config) error {
+		c.scopes = scopes
 		return nil
 	}
 }
@@ -32,6 +42,29 @@ func InitClientCredentials(issuer string, options ...func(*config) error) {
 	}
 
 	oauth.InitClientCredentials(issuer+"oauth/token",
+		oauth.Scopes(c.scopes...),
+		oauth.Extra(append([]string{"audience"}, c.extra...)...),
+		oauth.GetParams(func(profile map[string]string) url.Values {
+			return url.Values{
+				"audience": {profile["audience"]},
+			}
+		}))
+}
+
+// InitAuthCode sets up the Auth0 authorization code flow. Must be
+// called *after* you have called `cli.Init()`. Pass in profile-related extra
+// variables to store them alongside the default profile information.
+func InitAuthCode(clientID string, issuer string, options ...func(*config) error) {
+	var c config
+
+	for _, option := range options {
+		if err := option(&c); err != nil {
+			panic(err)
+		}
+	}
+
+	oauth.InitAuthCode(clientID, issuer+"authorize", issuer+"oauth/token",
+		oauth.Scopes(c.scopes...),
 		oauth.Extra(append([]string{"audience"}, c.extra...)...),
 		oauth.GetParams(func(profile map[string]string) url.Values {
 			return url.Values{

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -57,6 +57,7 @@ type Config struct {
 func Init(config *Config) {
 	initConfig(config.AppName, config.EnvPrefix)
 	initCache(config.AppName)
+	authInitialized = false
 
 	// Determine if we are using a TTY or colored output is forced-on.
 	tty = false

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+// execute a command against the configured CLI
+func execute(cmd string) string {
+	out := new(bytes.Buffer)
+	Root.SetArgs(strings.Split(cmd, " "))
+	Root.SetOutput(out)
+	Stdout = out
+	Stderr = out
+	Root.Execute()
+	return out.String()
+}
+
+func TestInit(t *testing.T) {
+	Cache = nil
+	Client = nil
+	Root = nil
+
+	viper.Set("color", true)
+
+	Init(&Config{
+		AppName: "test",
+	})
+
+	assert.NotNil(t, Cache)
+	assert.NotNil(t, Client)
+	assert.NotNil(t, Root)
+}
+
+func TestHelpCommands(t *testing.T) {
+	Init(&Config{
+		AppName: "test",
+	})
+
+	out := execute("help-config")
+	assert.Contains(t, out, "CLI Configuration")
+
+	out = execute("help-input")
+	assert.Contains(t, out, "CLI Request Input")
+}
+
+func TestPreRun(t *testing.T) {
+	Init(&Config{
+		AppName: "test",
+	})
+
+	ran := false
+	PreRun = func(cmd *cobra.Command, args []string) error {
+		ran = true
+		return nil
+	}
+
+	Root.Run = func(cmd *cobra.Command, args []string) {
+		// Do nothing, but also don't error.
+	}
+
+	execute("")
+
+	assert.True(t, ran)
+}

--- a/cli/credentials.go
+++ b/cli/credentials.go
@@ -161,6 +161,12 @@ func UseAuth(typeName string, handler AuthHandler) {
 	if typeName == "" {
 		// Backward-compatibility use-case without an explicit type. Set up the
 		// `add-profile` command as the only way to authenticate.
+		if authAddCommand.Run != nil {
+			// This fallback code path was already used, so we must be registering
+			// a *second* anonymous auth type, which is not allowed.
+			panic("register auth type names to use multi-auth")
+		}
+
 		authAddCommand.Use = "add-profile" + use
 		authAddCommand.Short = "Add a new named authentication profile"
 		authAddCommand.Args = cobra.ExactArgs(1 + len(keys))

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,7 @@ github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.2.1 h1:bIcUwXqLseLF3BDAZduuNfekWG87ibtFxi59Bq+oI9M=
 github.com/spf13/viper v1.2.1/go.mod h1:P4AexN0a+C9tGAnUFNwDMYYZv3pjFuvmeiMyKRaNVlI=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/oauth/authcode.go
+++ b/oauth/authcode.go
@@ -1,0 +1,183 @@
+package oauth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"context"
+
+	"github.com/danielgtaylor/openapi-cli-generator/cli"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
+	"golang.org/x/oauth2"
+	gcontext "gopkg.in/h2non/gentleman.v2/context"
+)
+
+// open opens the specified URL in the default browser regardless of OS.
+func open(url string) error {
+	var cmd string
+	var args []string
+
+	switch runtime.GOOS {
+	case "windows":
+		cmd = "cmd"
+		args = []string{"/c", "start"}
+	case "darwin":
+		cmd = "open"
+	default: // "linux", "freebsd", "openbsd", "netbsd"
+		cmd = "xdg-open"
+	}
+	args = append(args, url)
+	return exec.Command(cmd, args...).Start()
+}
+
+// authHandler is an HTTP handler that takes a channel and sends the `code`
+// query param when it gets a request.
+type authHandler struct {
+	c chan string
+}
+
+func (h authHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.c <- r.URL.Query().Get("code")
+	w.Header().Set("Content-Type", "text/html")
+	w.Write([]byte("<html><body><p>Login successful. Please return to the terminal. You may now close this window.</p></body></html>"))
+}
+
+// AuthorizationCodeTokenSource with PKCE as described in:
+// https://www.oauth.com/oauth2-servers/pkce/
+// This works by running a local HTTP server on port 8484 and then having the
+// user log in through a web browser, which redirects to the local server with
+// an authorization code. That code is then used to make another HTTP request
+// to fetch an auth token (and refresh token). That token is then in turn
+// used to make requests against the API.
+type AuthorizationCodeTokenSource struct {
+	ClientID       string
+	AuthorizeURL   string
+	TokenURL       string
+	EndpointParams *url.Values
+	Scopes         []string
+}
+
+// Token generates a new token using an authorization code.
+func (ac *AuthorizationCodeTokenSource) Token() (*oauth2.Token, error) {
+	// Generate a random code verifier string
+	verifierBytes := make([]byte, 32)
+	if _, err := rand.Read(verifierBytes); err != nil {
+		return nil, err
+	}
+
+	verifier := base64.RawURLEncoding.EncodeToString(verifierBytes)
+
+	// Generate a code challenge. Only the challenge is sent when requesting a
+	// code which allows us to keep it secret for now.
+	shaBytes := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(shaBytes[:])
+
+	// Generate a URL with the challenge to have the user log in.
+	url := fmt.Sprintf("%s?response_type=code&code_challenge=%s&code_challenge_method=S256&client_id=%s&redirect_uri=http://localhost:8484/&scope=%s", ac.AuthorizeURL, challenge, ac.ClientID, strings.Join(ac.Scopes, `%20`))
+
+	if len(*ac.EndpointParams) > 0 {
+		url += "&" + ac.EndpointParams.Encode()
+	}
+
+	// Run server before opening the user's browser so we are ready for any redirect.
+	codeChan := make(chan string)
+	handler := authHandler{
+		c: codeChan,
+	}
+
+	s := &http.Server{
+		Addr:           ":8484",
+		Handler:        handler,
+		ReadTimeout:    5 * time.Second,
+		WriteTimeout:   5 * time.Second,
+		MaxHeaderBytes: 1024,
+	}
+
+	go func() {
+		// Run in a goroutine until the server is closed or we get an error.
+		if err := s.ListenAndServe(); err != http.ErrServerClosed {
+			log.Fatal().Err(err).Msg("Server exited unexpectedly")
+		}
+	}()
+
+	// Open auth URL in browser, print for manual use in case open fails.
+	fmt.Println("Open your browser to log in using the URL:")
+	fmt.Println(url)
+	open(url)
+
+	// Get code from handler, exchange it for a token, and then return it. This
+	// channel read blocks until one code becomes available.
+	// There is currently no timeout.
+	code := <-codeChan
+	s.Shutdown(context.Background())
+
+	payload := fmt.Sprintf("grant_type=authorization_code&client_id=%s&code_verifier=%s&code=%s&redirect_uri=http://localhost:8484/", ac.ClientID, verifier, code)
+
+	return requestToken(ac.TokenURL, payload)
+}
+
+// InitAuthCode sets up the OAuth 2.0 authorization code with PKCE authentication
+// flow. Must be called *after* you have called `cli.Init()`. The endpoint
+// params allow you to pass additional info to the token URL. Pass in
+// profile-related extra variables to store them alongside the default profile
+// information.
+func InitAuthCode(clientID string, authorizeURL string, tokenURL string, options ...func(*config) error) {
+	var c config
+
+	for _, option := range options {
+		if err := option(&c); err != nil {
+			panic(err)
+		}
+	}
+
+	standard := []string{}
+
+	cli.InitCredentials(
+		cli.ProfileKeys(append(standard, c.extra...)...),
+		cli.ProfileListKeys())
+
+	cli.Client.UseRequest(func(ctx *gcontext.Context, h gcontext.Handler) {
+		if ctx.Request.Header.Get("Authorization") == "" {
+			// No auth is set, so let's get the token either from a cache
+			// or generate a new one from the issuing server.
+			profile := cli.GetProfile()
+
+			var params url.Values
+			if c.getParams != nil {
+				params = c.getParams(profile)
+			}
+
+			source := &AuthorizationCodeTokenSource{
+				ClientID:       clientID,
+				AuthorizeURL:   authorizeURL,
+				TokenURL:       tokenURL,
+				EndpointParams: &params,
+				Scopes:         c.scopes,
+			}
+
+			// Try to get a cached refresh token from the current profile and use
+			// it to wrap the auth code token source with a refreshing source.
+			refreshKey := "profiles." + viper.GetString("profile") + ".refresh"
+			refreshSource := RefreshTokenSource{
+				ClientID:       clientID,
+				TokenURL:       tokenURL,
+				EndpointParams: &params,
+				RefreshToken:   cli.Cache.GetString(refreshKey),
+				TokenSource:    source,
+			}
+
+			TokenMiddleware(refreshSource, ctx, h)
+		}
+
+		h.Next(ctx)
+	})
+}

--- a/oauth/clientcredentials.go
+++ b/oauth/clientcredentials.go
@@ -1,0 +1,103 @@
+package oauth
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/danielgtaylor/openapi-cli-generator/cli"
+	"github.com/rs/zerolog"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// NewClientCredentialsHandler creates a new handler.
+func NewClientCredentialsHandler(tokenURL string, keys, params, scopes []string) *ClientCredentialsHandler {
+	return &ClientCredentialsHandler{
+		TokenURL: tokenURL,
+		Keys:     append([]string{"client-id", "client-secret"}, keys...),
+		Params:   params,
+		Scopes:   scopes,
+	}
+}
+
+// ClientCredentialsHandler implements the Client Credentials OAuth2 flow.
+type ClientCredentialsHandler struct {
+	TokenURL string
+	Keys     []string
+	Params   []string
+	Scopes   []string
+
+	getParamsFunc func(profile map[string]string) url.Values
+}
+
+// ProfileKeys returns the key names for fields to store in the profile.
+func (h *ClientCredentialsHandler) ProfileKeys() []string {
+	return h.Keys
+}
+
+// OnRequest gets run before the request goes out on the wire.
+func (h *ClientCredentialsHandler) OnRequest(log *zerolog.Logger, request *http.Request) error {
+	if request.Header.Get("Authorization") == "" {
+		// No auth is set, so let's get the token either from a cache
+		// or generate a new one from the issuing server.
+		profile := cli.GetProfile()
+
+		if profile["client_id"] == "" {
+			return ErrInvalidProfile
+		}
+
+		if profile["client_secret"] == "" {
+			return ErrInvalidProfile
+		}
+
+		params := url.Values{}
+		if h.getParamsFunc != nil {
+			// Backward-compatibility with old call style, only used internally.
+			params = h.getParamsFunc(profile)
+		}
+		for _, name := range h.Params {
+			params.Add(name, profile[name])
+		}
+
+		source := (&clientcredentials.Config{
+			ClientID:       profile["client_id"],
+			ClientSecret:   profile["client_secret"],
+			TokenURL:       h.TokenURL,
+			EndpointParams: params,
+			Scopes:         h.Scopes,
+		}).TokenSource(oauth2.NoContext)
+
+		return TokenHandler(source, log, request)
+	}
+
+	return nil
+}
+
+// InitClientCredentials sets up the OAuth 2.0 client credentials authentication
+// flow. Must be called *after* you have called `cli.Init()`. The endpoint
+// params allow you to pass additional info to the token URL. Pass in
+// profile-related extra variables to store them alongside the default profile
+// information.
+func InitClientCredentials(tokenURL string, options ...func(*config) error) {
+	var c config
+
+	for _, option := range options {
+		if err := option(&c); err != nil {
+			panic(err)
+		}
+	}
+
+	handler := NewClientCredentialsHandler(tokenURL, c.extra, []string{}, c.scopes)
+
+	// Since you can pass a function to get params, we can't use the normal
+	// preset `Params` field. We use an internal field here for backwards
+	// compatibility only.
+	handler.getParamsFunc = c.getParams
+
+	cli.UseAuth("", handler)
+
+	// TODO: retry on 401
+	// cli.Client.UseResponse(func(ctx *context.Context, h context.Handler) {
+	// 	h.Next(ctx)
+	// })
+}

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -103,7 +103,13 @@ func TokenHandler(source oauth2.TokenSource, log *zerolog.Logger, request *http.
 		cli.Cache.Set(expiresKey, token.Expiry)
 		cli.Cache.Set(typeKey, token.Type())
 		cli.Cache.Set(tokenKey, token.AccessToken)
-		cli.Cache.Set(refreshKey, token.RefreshToken)
+
+		if token.RefreshToken != "" {
+			// Only set the refresh token if present. This prevents overwriting it
+			// after using a refresh token, because the newly returned token won't
+			// have another refresh token set on it (you keep using the same one).
+			cli.Cache.Set(refreshKey, token.RefreshToken)
+		}
 
 		// Save the cache to disk.
 		if err := cli.Cache.WriteConfig(); err != nil {

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -17,6 +17,7 @@ import (
 type config struct {
 	getParams func(profile map[string]string) url.Values
 	extra     []string
+	scopes    []string
 }
 
 // ErrInvalidProfile is thrown when a profile is missing or invalid.
@@ -36,6 +37,14 @@ func GetParams(f func(profile map[string]string) url.Values) func(*config) error
 func Extra(names ...string) func(*config) error {
 	return func(c *config) error {
 		c.extra = names
+		return nil
+	}
+}
+
+// Scopes sets a list of scopes to request for the token.
+func Scopes(scopes ...string) func(*config) error {
+	return func(c *config) error {
+		c.scopes = scopes
 		return nil
 	}
 }
@@ -81,6 +90,7 @@ func InitClientCredentials(tokenURL string, options ...func(*config) error) {
 				ClientSecret:   profile["client_secret"],
 				TokenURL:       tokenURL,
 				EndpointParams: params,
+				Scopes:         c.scopes,
 			}).TokenSource(oauth2.NoContext)
 
 			TokenMiddleware(source, ctx, h)

--- a/oauth/refresh.go
+++ b/oauth/refresh.go
@@ -1,0 +1,55 @@
+package oauth
+
+import (
+	"fmt"
+	"net/url"
+
+	"golang.org/x/oauth2"
+)
+
+// RefreshTokenSource will use a refresh token to try and get a new token before
+// calling the original token source to get a new token.
+type RefreshTokenSource struct {
+	// ClientID of the application
+	ClientID string
+
+	// TokenURL is used to fetch new tokens
+	TokenURL string
+
+	// EndpointParams are extra URL query parameters to include in the request
+	EndpointParams *url.Values
+
+	// RefreshToken from a cache, if available. If not, then the first time a
+	// token is requested it will be loaded from the token source and this value
+	// will get updated if it's present in the returned token.
+	RefreshToken string
+
+	// TokenSource to wrap to fetch new tokens if the refresh token is missing or
+	// did not work to get a new token.
+	TokenSource oauth2.TokenSource
+}
+
+// Token generates a new token using either a refresh token or by falling
+// back to the original source.
+func (ts RefreshTokenSource) Token() (*oauth2.Token, error) {
+	if ts.RefreshToken != "" {
+		payload := fmt.Sprintf("grant_type=refresh_token&client_id=%s&refresh_token=%s", ts.ClientID, ts.RefreshToken)
+
+		token, err := requestToken(ts.TokenURL, payload)
+		if err == nil {
+			return token, err
+		}
+
+		// Couldn't refresh, try the original source again.
+	}
+
+	token, err := ts.TokenSource.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	// Update the initial token with the (possibly new) refresh token.
+	ts.RefreshToken = token.RefreshToken
+
+	return token, nil
+}

--- a/oauth/refresh.go
+++ b/oauth/refresh.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/rs/zerolog/log"
 	"golang.org/x/oauth2"
 )
 
@@ -33,6 +34,7 @@ type RefreshTokenSource struct {
 // back to the original source.
 func (ts RefreshTokenSource) Token() (*oauth2.Token, error) {
 	if ts.RefreshToken != "" {
+		log.Debug().Msg("Trying refresh token to get a new access token")
 		payload := fmt.Sprintf("grant_type=refresh_token&client_id=%s&refresh_token=%s", ts.ClientID, ts.RefreshToken)
 
 		token, err := requestToken(ts.TokenURL, payload)

--- a/oauth/request.go
+++ b/oauth/request.go
@@ -42,6 +42,8 @@ func requestToken(tokenURL, payload string) (*oauth2.Token, error) {
 	defer res.Body.Close()
 	body, _ := ioutil.ReadAll(res.Body)
 
+	log.Debug().Str("url", tokenURL).Bytes("body", body).Msg("Got response")
+
 	if res.StatusCode > 200 {
 		return nil, fmt.Errorf("bad response from token endpoint:\n%s", body)
 	}

--- a/oauth/request.go
+++ b/oauth/request.go
@@ -1,0 +1,67 @@
+package oauth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"golang.org/x/oauth2"
+)
+
+// tokenResponse is used to parse responses from token providers and make sure
+// the expiration time is set properly regardless of whether `expires_in` or
+// `expiry` is returned.
+type tokenResponse struct {
+	TokenType    string        `json:"token_type"`
+	AccessToken  string        `json:"access_token"`
+	RefreshToken string        `json:"refresh_token,omitempty"`
+	ExpiresIn    time.Duration `json:"expires_in"`
+	Expiry       time.Time     `json:"expiry,omitempty"`
+}
+
+// requestToken from the given URL with the given payload. This can be used
+// for many different grant types and will return a parsed token.
+func requestToken(tokenURL, payload string) (*oauth2.Token, error) {
+	log.Debug().Str("url", tokenURL).Str("payload", payload).Msg("Fetching token")
+	req, err := http.NewRequest("POST", tokenURL, strings.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("content-type", "application/x-www-form-urlencoded")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+	body, _ := ioutil.ReadAll(res.Body)
+
+	if res.StatusCode > 200 {
+		return nil, fmt.Errorf("bad response from token endpoint:\n%s", body)
+	}
+
+	decoded := tokenResponse{}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, err
+	}
+
+	expiry := decoded.Expiry
+	if expiry.IsZero() {
+		expiry = time.Now().Add(decoded.ExpiresIn * time.Second)
+	}
+
+	token := &oauth2.Token{
+		AccessToken:  decoded.AccessToken,
+		TokenType:    decoded.TokenType,
+		RefreshToken: decoded.RefreshToken,
+		Expiry:       expiry,
+	}
+
+	return token, nil
+}


### PR DESCRIPTION
This adds a new mechanism to register auth middleware and allows setting up multiple types of auth in a single generated CLI.

For example, you may want individual user's to log in but also support a machine-to-machine scenario for scripting and services. You would set up an AuthCode-based flow for users and a ClientCredentials-based flow for getting machine-to-machine tokens.

This change is backward compatible and the old calls continue to work (in fact, they are now built on top of the new `UseAuth(...)` functionality).