### PR TITLE
Case format

### DIFF
--- a/main.go
+++ b/main.go
@@ -282,17 +282,17 @@ func ProcessAPI(shortName string, api *openapi3.Swagger) *OpenAPI {
 			}
 
 			o := &Operation{
-				HandlerName:    slug(name),
-				GoName:         toGoName(name, true),
-				Use:            use,
-				Aliases:        aliases,
-				Short:          short,
-				Long:           escapeString(description),
-				Method:         method,
-				CanHaveBody:    method == "Post" || method == "Put" || method == "Patch",
-				ReturnType:     returnType,
-				Path:           path,
-				AllParams:      params,
+				HandlerName: Slug(name),
+				GoName:      toGoName(name, true),
+				Use:         use,
+				Aliases:     aliases,
+				Short:       short,
+				Long:        escapeString(description),
+				Method:      method,
+				CanHaveBody: method == "Post" || method == "Put" || method == "Patch",
+				ReturnType:  returnType,
+				Path:        path,
+				AllParams:   params,
 				RequiredParams: requiredParams,
 				OptionalParams: optionalParams,
 				MediaType:      reqMt,
@@ -326,7 +326,7 @@ func ProcessAPI(shortName string, api *openapi3.Swagger) *OpenAPI {
 		}
 
 		for name, waiter := range waiters {
-			waiter.CLIName = slug(name)
+			waiter.CLIName = Slug(name)
 			waiter.GoName = toGoName(name+"-waiter", true)
 			waiter.Operation = operationMap[waiter.OperationID]
 			waiter.Use = usage(name, waiter.Operation.RequiredParams)
@@ -420,7 +420,7 @@ func escapeString(value string) string {
 	return transformed
 }
 
-func slug(operationID string) string {
+func Slug(operationID string) string {
 	re, _ := regexp.Compile("([a-z])([A-Z])")
 	transformed := re.ReplaceAllString(operationID, "$1-$2")
 	transformed = strings.ToLower(transformed)
@@ -430,10 +430,10 @@ func slug(operationID string) string {
 }
 
 func usage(name string, requiredParams []*Param) string {
-	usage := slug(name)
+	usage := Slug(name)
 
 	for _, p := range requiredParams {
-		usage += " " + slug(p.Name)
+		usage += " " + Slug(p.Name)
 	}
 
 	return usage
@@ -465,7 +465,7 @@ func getParams(path *openapi3.PathItem, httpMethod string) []*Param {
 				}
 			}
 
-			cliName := slug(p.Value.Name)
+			cliName := Slug(p.Value.Name)
 			if p.Value.Extensions[ExtName] != nil {
 				cliName = extStr(p.Value.Extensions[ExtName])
 			}
@@ -634,7 +634,7 @@ func generate(cmd *cobra.Command, args []string) {
 
 	funcs := template.FuncMap{
 		"escapeStr": escapeString,
-		"slug":      slug,
+		"Slug":      Slug,
 		"title":     strings.Title,
 	}
 

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -420,7 +421,9 @@ func escapeString(value string) string {
 }
 
 func slug(operationID string) string {
-	transformed := strings.ToLower(operationID)
+	re, _ := regexp.Compile("([a-z])([A-Z])")
+	transformed := re.ReplaceAllString(operationID, "$1-$2")
+	transformed = strings.ToLower(transformed)
 	transformed = strings.Replace(transformed, "_", "-", -1)
 	transformed = strings.Replace(transformed, " ", "-", -1)
 	return transformed

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	main "github.com/danielgtaylor/openapi-cli-generator"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -70,4 +71,28 @@ func TestEchoSuccess(t *testing.T) {
 	}
 
 	assert.JSONEq(t, "{\"hello\": \"world\", \"q\": \"foo\", \"request-id\": \"bar\"}", string(out))
+}
+
+func Test_slug(t *testing.T) {
+	type args struct {
+		operationID string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{name: "lowercase with spaces", args: args{operationID: "get all articles"}, want: "get-all-articles"},
+		{name: "Mixed sentence case", args: args{operationID: "Get all articles"}, want: "get-all-articles"},
+		{name: "lower snake case", args: args{operationID: "get_all_articles"}, want: "get-all-articles"},
+		{name: "upper snake case", args: args{operationID: "GET_ALL_ARTICLES"}, want: "get-all-articles"},
+		{name: "kebab case", args: args{operationID: "get-all-articles"}, want: "get-all-articles"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := main.Slug(tt.args.operationID); got != tt.want {
+				t.Errorf("Slug() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Updated generator to transform lowerCamelCase operation names into idiomatic CLI kebab-case. This is useful for processing specs auto-generated from Spr**g MVC services.

(I have added a test but unsure if main_test.go is the right place - exporting `Slug()` in main.go feels icky but it also seems too small to add a new module.  Please feel free to change as you like)