### PR TITLE
Add new "--output" flag to command generate

### DIFF
--- a/main.go
+++ b/main.go
@@ -651,7 +651,12 @@ func generate(cmd *cobra.Command, args []string) {
 		panic(err)
 	}
 
-	writeFormattedFile(shortName+".go", []byte(sb.String()))
+	output := shortName+".go"
+	if o, _ := cmd.Flags().GetString("output"); o != "" {
+		output = o
+	}
+
+	writeFormattedFile(output, []byte(sb.String()))
 }
 
 func main() {
@@ -664,12 +669,15 @@ func main() {
 		Run:   initCmd,
 	})
 
-	root.AddCommand(&cobra.Command{
+	generateCmd := &cobra.Command{
 		Use:   "generate <api-spec>",
 		Short: "Generate a `commands.go` file from an OpenAPI spec",
 		Args:  cobra.ExactArgs(1),
 		Run:   generate,
-	})
+	}
+	generateCmd.Flags().StringP("output", "o", "",
+		"specify an alternative output file for generated code")
+	root.AddCommand(generateCmd)
 
 	root.Execute()
 }


### PR DESCRIPTION
This change introduces an optional `--output|-o` flag to the `generate`
command, allowing users to specify an alternative output file for
generated code instead of the name of the input OpenAPI spec file.