### PR TITLE
feat(auth): Enable default values for params

### DIFF
--- a/oauth/authcode.go
+++ b/oauth/authcode.go
@@ -128,12 +128,13 @@ func (ac *AuthorizationCodeTokenSource) Token() (*oauth2.Token, error) {
 // AuthCodeHandler sets up the OAuth 2.0 authorization code with PKCE authentication
 // flow.
 type AuthCodeHandler struct {
-	ClientID     string
-	AuthorizeURL string
-	TokenURL     string
-	Keys         []string
-	Params       []string
-	Scopes       []string
+	ClientID      string
+	AuthorizeURL  string
+	TokenURL      string
+	Keys          []string
+	Params        []string
+	Scopes        []string
+	DefaultValues map[string]string
 
 	getParamsFunc func(profile map[string]string) url.Values
 }
@@ -156,7 +157,11 @@ func (h *AuthCodeHandler) OnRequest(log *zerolog.Logger, request *http.Request) 
 			params = h.getParamsFunc(profile)
 		}
 		for _, name := range h.Params {
-			params.Add(name, profile[name])
+			if val, ok := profile[name]; ok {
+				params.Add(name, val)
+			} else {
+				params.Add(name, h.DefaultValues[name])
+			}
 		}
 
 		source := &AuthorizationCodeTokenSource{


### PR DESCRIPTION
This PR hopes to allow the ability for consumers to add default values for parameters that will be sent up alongside the oauth2 authorizationCode request. Currently, you can add parameters that must be filled out by the user input when setting up a profile, this change allows us to define default values as a way to encode query params such as `audience` client_id params without needing the user to configure it themselves.